### PR TITLE
Installing is now required for regular PSM because it just doesn't work otherwise

### DIFF
--- a/Exploit.cs
+++ b/Exploit.cs
@@ -610,8 +610,12 @@ namespace VitaDefiler.PSM
 
                 Console.WriteLine("Successfully installed package.");
 
-                Thread.Sleep(1000);
-                Environment.Exit(0);
+                Thread.Sleep(500);
+
+                if (Program.exitAfterInstall)
+                {
+                    Environment.Exit(0);
+                }
             }
 
             if (useUsb)

--- a/Program.cs
+++ b/Program.cs
@@ -12,6 +12,8 @@ namespace VitaDefiler
     {
         static readonly Type[] Mods = {typeof(Code), typeof(General), typeof(Memory), typeof(FileIO), typeof(Scripting)};
 
+        public static bool exitAfterInstall = false;
+
         static void Main(string[] args)
         {
             int scriptIndex = 0;
@@ -30,9 +32,24 @@ namespace VitaDefiler
                     case "-install":
                         scriptIndex += 2;
                         package = args[0];
+                        exitAfterInstall = true;
                         break;
                 }
             }
+
+#if !USE_UNITY
+            if (args.Length < 1)
+            {
+                Console.Error.WriteLine("usage: VitaDefiler.exe package [-nodisp] [script args]\n    package is path to PSM package\n    nodisp starts client without logging to screen\n    script is the script to run\n    args are arguments for the script");
+                return;
+            }
+
+            if (string.IsNullOrEmpty(package))
+            {
+                package = args[0];
+                ++scriptIndex;
+            }
+#endif
 
             if (!string.IsNullOrEmpty(package) && !File.Exists(package))
             {


### PR DESCRIPTION
For whatever reason, running homebrew with regular PSM doesn't work unless VitaDefilerClient is installed right before, even if it was already installed.